### PR TITLE
Fixed bug in PBS job definition with explicit partition attribute

### DIFF
--- a/src/benchmarktool/runscript/parser.py
+++ b/src/benchmarktool/runscript/parser.py
@@ -280,7 +280,7 @@ class Parser:
         run  = Runscript(root.get("output"))
 
         for node in root.xpath("./pbsjob"):
-            attr = self._filterAttr(node, ["name", "timeout", "runs", "ppn", "procs", "script_mode", "walltime", "cpt"])
+            attr = self._filterAttr(node, ["name", "timeout", "runs", "ppn", "procs", "script_mode", "walltime", "cpt", "partition"])
         
             partition = node.get("partition")
             if partition == None:


### PR DESCRIPTION
Explicitly specifying the partition attribute in the PBS job (eg, partition="kr") causes an error in the resulting generated XML after running "beval". The resulting XML contains two partition attributes (which makes it invalid XML). To fix just needed to add "partition" to the attribute filter list.
