### PR TITLE
Ensure that "seqjob" tasks are executed in their own session.

### DIFF
--- a/src/benchmarktool/runscript/runscript.py
+++ b/src/benchmarktool/runscript/runscript.py
@@ -458,7 +458,12 @@ class Run(threading.Thread):
     
     def run(self):
         path, script = os.path.split(self.cmd)
-        self.proc = subprocess.Popen(["bash", script, str(self.core)], cwd=path)
+        openArgs = dict(cwd=path)
+        if sys.version_info[:3] >= (3,2,0):
+            openArgs["start_new_session"] = True
+        else:
+            openArgs["preexec_fn"] = os.setsid
+        self.proc = subprocess.Popen(["bash", script, str(self.core)], **openArgs)
         self.proc.wait()
         self.main.finish(self)
 


### PR DESCRIPTION
* Parallel "seqjob" tasks should be isolated from each other as otherwise tools like `runlim` will kill all running tasks once the first task finishes.

* NOTE: Unfortunately, the dedicated `start_new_session` argument of subprocess.Popen has only been added in version 3.2. For older versions, we use the `preexec_fn` to invoke os.setsid as described in the python docs.