### PR TITLE
Minor adjustments.

### DIFF
--- a/programs/gcat.sh
+++ b/programs/gcat.sh
@@ -3,12 +3,12 @@
 function bat()
 {
     for x in "$@"; do
-        type=$(file -bi "$(readlink -f "${x}")")
+        type=$(file -b --mime-type -L "${x}")
         case ${type} in
-        "application/x-bzip2"|"application/x-bzip2; charset=binary")
+        application/*bzip2*)
             bzcat "${x}"
             ;;
-        "application/x-gzip"|"application/x-gzip; charset=binary")
+	application/*gzip*)
             zcat "${x}"
             ;;
         *)

--- a/src/benchmarktool/resultparser/clasp.py
+++ b/src/benchmarktool/resultparser/clasp.py
@@ -12,14 +12,14 @@ import codecs
 clasp_re = {
     "models"      : ("float", re.compile(r"^(c )?Models[ ]*:[ ]*(?P<val>[0-9]+)\+?[ ]*$")),
     "choices"     : ("float", re.compile(r"^(c )?Choices[ ]*:[ ]*(?P<val>[0-9]+)\+?[ ]*$")),
-    "time"        : ("float", re.compile(r"^Real time \(s\): (?P<val>[0-9]+(\.[0-9]+)?)$")),
+    "time"        : ("float", re.compile(r"^(Real time \(s\):|\[runlim\] real:)\s*(?P<val>[0-9]+(\.[0-9]+)?)")),
     "conflicts"   : ("float", re.compile(r"^(c )?Conflicts[ ]*:[ ]*(?P<val>[0-9]+)\+?[ ]*$")),
     "restarts"    : ("float", re.compile(r"^(c )?Restarts[ ]*:[ ]*(?P<val>[0-9]+)\+?[ ]*$")),
     "optimum"     : ("string", re.compile(r"^(c )?Optimization[ ]*:[ ]*(?P<val>(-?[0-9]+)( -?[0-9]+)*)[ ]*$")),
     "status"      : ("string", re.compile(r"^(s )?(?P<val>SATISFIABLE|UNSATISFIABLE|UNKNOWN|OPTIMUM FOUND)[ ]*$")),
     "interrupted" : ("string", re.compile(r"(c )?(?P<val>INTERRUPTED!)")),
     "error"       : ("string", re.compile(r"^\*\*\* clasp ERROR: (?P<val>.*)$")),
-    "memerror"    : ("string", re.compile(r"^Maximum VSize (?P<val>exceeded): sending SIGTERM then SIGKILL")),
+    "memerror"    : ("string", re.compile(r"^(Maximum VSize exceeded|\[runlim\] status:\s*out of memory)(?P<val>.*)")),
 }
 
 def clasp(root, runspec, instance):


### PR DESCRIPTION
* Add runlim support to clasp result parser.
* Simplify and generalize gcat.sh:
  - accept both x- and plain gzip/bzip
  - use file's "dereference" option instead of readlink