### PR TITLE
Minor Adjustments (for discussion)

### DIFF
--- a/docs/examples/index.md
+++ b/docs/examples/index.md
@@ -7,7 +7,7 @@ hide:
 
 ## Sequential Benchmark
 
-The example assumes that you want to run a benchmark that shall be started using simple bash scripts. All the following instruction assume that the current working directory is the root directory of the benchmark-tool project. To begin, the two executables [clasp-3.4.0][1] and [runlim-2.0.0rc12][2] have to be copied (or symlinked) into the `./programs` folder.  
+The example assumes that you want to run a benchmark that shall be started using simple bash scripts. All the following instruction assume that the current working directory is the root directory of the benchmark-tool project. To begin, the two executables [clasp-3.4.0][1] and [runlim][2] have to be copied (or symlinked) into the `./programs` folder.  
 Now, run:  
 `$ bgen ./runscripts/runscript-seq.xml`  
 This creates a set of start scripts in the `./output` folder.  
@@ -20,7 +20,7 @@ Finally, open the file:
 
 ## Cluster Benchmark
 
-This example assumes that you want to run a benchmark on a cluster, i.g. on the [HPC][3] cluster at the university of Potsdam. Again, all the following instruction assume that the current working directory is the root directory of the benchmark-tool project. Once again make sure, the two executables [clasp-3.4.0][1] and [runlim-2.0.0rc12][2] have been copied (or symlinked) into the `./programs` folder.  
+This example assumes that you want to run a benchmark on a cluster, i.g. on the [HPC][3] cluster at the university of Potsdam. Again, all the following instruction assume that the current working directory is the root directory of the benchmark-tool project. Once again make sure, the two executables [clasp-3.4.0][1] and [runlim][2] have been copied (or symlinked) into the `./programs` folder.  
 Now, run:  
 `$ bgen ./runscripts/runscript-dist.xml`  
 This creates a set of start scripts in the `./output` folder.  
@@ -38,7 +38,7 @@ While [runscript-example.xml](https://github.com/potassco/benchmark-tool/blob/ma
 
 Examples for the encoding support feature can be found [here](../reference/encoding_support.md).
 
-For a more detailed explanation of a runsript and its components check [here](../getting_started/bgen/runscript.md)
+For a more detailed explanation of a runscript and its components check [here](../getting_started/bgen/runscript.md)
 
 [1]: https://potassco.org/clasp/
 [2]: https://github.com/arminbiere/runlim

--- a/docs/getting_started/bgen/templates.md
+++ b/docs/getting_started/bgen/templates.md
@@ -16,6 +16,7 @@ The following references can currently be used:
 `run.encodings`: encoding files to be used for this instance  
 `run.root`: the path to the benchmark-tool folder  
 `run.timeout`: the walltime for this run  
+`run.memout`: the memory limit for this run in MB (20000 by default)  
 `run.solver`: the solver/program to be used for this run  
 `run.args`: additional arguments to be used by the solver/program  
 

--- a/docs/getting_started/index.md
+++ b/docs/getting_started/index.md
@@ -52,6 +52,6 @@ A detailed description on how to use each component can be accessed via the side
     ```
     This is a known issue, see <https://github.com/arminbiere/runlim/issues/8>.
 
-    For single-process systems under test (SUT) this issue can be avoided by using the `runlim` option `--single` in the corresponding template script (e.g. `templates/seq-generic.sh`). In that case, `{run.solver}` should either be the SUT executable or `exec` should be used if `{run.solver}` refers to a shell script.
+    For single-process systems under test (SUT) this issue can be avoided by using the `runlim` option `--single` in the corresponding template script (e.g. `templates/seq-generic-single.sh`). In that case, `{run.solver}` should either be the SUT executable or `exec` should be used if `{run.solver}` refers to a shell script.
 
     If you can't or don't want to use `--single`, the [verify_results.sh](https://github.com/potassco/benchmark-tool/blob/master/verify_results.sh) script can be used to find jobs, which failed due to a `runlim error`, delete the corresponding `.finished` files and create a new start script excluding jobs already run.

--- a/src/benchmarktool/runscript/parser.py
+++ b/src/benchmarktool/runscript/parser.py
@@ -135,6 +135,7 @@ class Parser:
         <xs:attribute name="name" type="nameType" use="required"/>
         <xs:attribute name="timeout" type="timeType" use="required"/>
         <xs:attribute name="runs" type="xs:positiveInteger" use="required"/>
+        <xs:attribute name="memout" type="xs:positiveInteger"/>
         <xs:anyAttribute processContents="lax"/>
     </xs:attributeGroup>
 

--- a/src/benchmarktool/runscript/runscript.py
+++ b/src/benchmarktool/runscript/runscript.py
@@ -236,6 +236,7 @@ class SeqRun(Run):
         args (str):        The command line arguments for this run.
         solver (str):      The solver for this run.
         timeout (int):     The timeout of this run.
+        memout (int):      The memory limit of this run.
     """
 
     run: int
@@ -248,6 +249,7 @@ class SeqRun(Run):
     args: str = field(init=False)
     sovler: str = field(init=False)
     timeout: int = field(init=False)
+    memout: int = field(init=False)
 
     def __post_init__(self) -> None:
         super().__post_init__()
@@ -262,6 +264,7 @@ class SeqRun(Run):
         self.args = self.runspec.setting.cmdline
         self.solver = self.runspec.system.name + "-" + self.runspec.system.version
         self.timeout = self.job.timeout
+        self.memout = int(self.job.attr.get("memout", 20000))
 
 
 class ScriptGen:

--- a/templates/seq-generic-single.sh
+++ b/templates/seq-generic-single.sh
@@ -9,7 +9,7 @@ cd "$(dirname $0)"
 
 runner=( "{run.root}/programs/runlim" \
   --single \
-  --space-limit=20000 \
+  --space-limit={run.memout} \
   --output-file=runsolver.watcher \
   --real-time-limit={run.timeout} \
   "{run.root}/programs/{run.solver}" {run.args})

--- a/templates/seq-generic-single.sh
+++ b/templates/seq-generic-single.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+# https://github.com/arminbiere/runlim
+
+CAT="{run.root}/programs/gcat.sh"
+
+cd "$(dirname $0)"
+
+#top -n 1 -b > top.txt
+
+runner=( "{run.root}/programs/runlim" \
+  --single \
+  --space-limit=20000 \
+  --output-file=runsolver.watcher \
+  --real-time-limit={run.timeout} \
+  "{run.root}/programs/{run.solver}" {run.args})
+
+input=( {run.files} {run.encodings} )
+
+if [[ ! -e .finished ]]; then
+  {{
+    if file -b --mime-type -L  "${{input[@]}}" | grep -qv "text/"; then
+      "$CAT" "${{input[@]}}" | "${{runner[@]}}"
+    else
+      "${{runner[@]}}" "${{input[@]}}"
+    fi
+  }} > runsolver.solver
+fi
+
+touch .finished

--- a/templates/seq-generic-zip.sh
+++ b/templates/seq-generic-zip.sh
@@ -8,7 +8,7 @@ cd "$(dirname $0)"
 #top -n 1 -b > top.txt
 
 [[ -e .finished ]] || $CAT {run.files} {run.encodings} | "{run.root}/programs/runlim" \
-	--space-limit=20000 \
+	--space-limit={run.memout} \
 	--output-file=runsolver.watcher \
 	--real-time-limit={run.timeout} \
 	"{run.root}/programs/{run.solver}" {run.args} > runsolver.solver

--- a/templates/seq-generic-zip.sh
+++ b/templates/seq-generic-zip.sh
@@ -7,7 +7,7 @@ cd "$(dirname $0)"
 
 #top -n 1 -b > top.txt
 
-[[ -e .finished ]] || $CAT {run.files} {run.encodings} | "{run.root}/programs/runlim-2.0.0rc12" \
+[[ -e .finished ]] || $CAT {run.files} {run.encodings} | "{run.root}/programs/runlim" \
 	--space-limit=20000 \
 	--output-file=runsolver.watcher \
 	--real-time-limit={run.timeout} \

--- a/templates/seq-generic.sh
+++ b/templates/seq-generic.sh
@@ -8,7 +8,7 @@ cd "$(dirname $0)"
 #top -n 1 -b > top.txt
 
 [[ -e .finished ]] || "{run.root}/programs/runlim" \
-	--space-limit=20000 \
+	--space-limit={run.memout} \
 	--output-file=runsolver.watcher \
 	--real-time-limit={run.timeout} \
 	"{run.root}/programs/{run.solver}" {run.args} {run.files} {run.encodings} > runsolver.solver

--- a/templates/seq-generic.sh
+++ b/templates/seq-generic.sh
@@ -7,7 +7,7 @@ cd "$(dirname $0)"
 
 #top -n 1 -b > top.txt
 
-[[ -e .finished ]] || "{run.root}/programs/runlim-2.0.0rc12" \
+[[ -e .finished ]] || "{run.root}/programs/runlim" \
 	--space-limit=20000 \
 	--output-file=runsolver.watcher \
 	--real-time-limit={run.timeout} \

--- a/tests/ref/test_template.sh
+++ b/tests/ref/test_template.sh
@@ -1,1 +1,1 @@
-$CAT {run.files} {run.root} {run.timeout} {run.root}/programs/{run.solver} {run.args} {run.encodings}
+$CAT {run.files} {run.root} {run.timeout} {run.memout} {run.root}/programs/{run.solver} {run.args} {run.encodings}

--- a/tests/runscript/test_runscript_classes.py
+++ b/tests/runscript/test_runscript_classes.py
@@ -266,6 +266,7 @@ class TestSeqRun(TestRun):
         self.run_var = 1
         self.job = mock.Mock(spec=runscript.Job)
         self.job.timeout = 10
+        self.job.attr = {"memout": "10000"}
         self.runspec = mock.Mock(spec=runscript.Runspec)
         self.runspec.setting = mock.Mock(spec=runscript.Setting)
         self.runspec.setting.cmdline = "cmdline"
@@ -330,6 +331,7 @@ class TestScriptGen(TestCase):
 
         self.sg.job.runs = 1
         self.sg.job.timeout = 10
+        self.sg.job.attr = {"memout": "20"}
 
         self.instance = mock.Mock(spec=runscript.Benchmark.Instance)
         self.instance.name = "inst_name"
@@ -388,7 +390,7 @@ class TestScriptGen(TestCase):
         if platform.system() == "Linux":
             self.assertEqual(
                 x,
-                '$CAT "../../inst_path.lp" ../.. 10 ../../programs/sys_name-sys_version cmdline "../../encoding"\n',
+                '$CAT "../../inst_path.lp" ../.. 10 20 ../../programs/sys_name-sys_version cmdline "../../encoding"\n',
             )
         os.remove("./tests/ref/start.sh")
 


### PR DESCRIPTION
* **Remove runlim version from run templates ([#issue 33](https://github.com/potassco/benchmark-tool/issues/33))**
* **Add run template for single-process solvers**
  * Single-process solvers like clasp can use runlim's "--single"
  option thereby avoiding a known issue in runlim's group tracking.
  * To avoid further duplication, the seq-generic-single.sh template
  combines the input handling logic of seq-generic.sh and
  seq-generic-zip.sh into one template.
* **Add support for configurable memory limit**
  * Allow (optional) attribute "memout" in job and pass it via
  "run.memout" to run template.