### PR TITLE
Fix issues caused by missing measures in some settings

### DIFF
--- a/src/benchmarktool/result/ods_gen.py
+++ b/src/benchmarktool/result/ods_gen.py
@@ -350,7 +350,7 @@ class Sheet:
             benchclass_summary (dict[str, Any]): Summary of benchmark class.
         """
         for name, value in benchclass_summary.items():
-            if not value is None:
+            if value is not None:
                 temp_res = value[0] / value[1]
                 if name == "timeout":
                     temp_res = value[0]
@@ -374,7 +374,10 @@ class Sheet:
             self.content = self.content.set_axis(list(range(len(self.content.columns))), axis=1)
             self.content.at[0, col] = block.gen_name(len(self.machines) > 1)
             for m in block.columns:
-                self.types[m] = block.columns[m]
+                if m not in self.types:
+                    self.types[m] = block.columns[m]
+                elif self.types[m] == "None" or self.types[m] == "empty":
+                    self.types[m] = block.columns[m]
             col += len(block.columns)
 
         # get columns used for summary calculations
@@ -493,7 +496,9 @@ class Sheet:
                 ref_value = "{0}:{1}".format(
                     get_cell_index(col, 2, True), get_cell_index(col, self.result_offset - 1, True)
                 )
-                values = np.array(self.values.loc[2 : self.result_offset - 1, col])
+                values = np.array(self.values.loc[2 : self.result_offset - 1, col], dtype=float)
+                if np.isnan(values).all():
+                    continue
                 # SUM
                 self.content.at[self.result_offset + 1, col] = Formula("SUM({0})".format(ref_value))
                 self.values.at[self.result_offset + 1, col] = np.nansum(values)

--- a/src/benchmarktool/result/ods_gen.py
+++ b/src/benchmarktool/result/ods_gen.py
@@ -374,9 +374,7 @@ class Sheet:
             self.content = self.content.set_axis(list(range(len(self.content.columns))), axis=1)
             self.content.at[0, col] = block.gen_name(len(self.machines) > 1)
             for m in block.columns:
-                if m not in self.types:
-                    self.types[m] = block.columns[m]
-                elif self.types[m] == "None" or self.types[m] == "empty":
+                if m not in self.types or self.types[m] in ("None", "empty"):
                     self.types[m] = block.columns[m]
             col += len(block.columns)
 

--- a/tests/ref/test_eval.xml
+++ b/tests/ref/test_eval.xml
@@ -188,7 +188,6 @@
 						<measure name="memout" type="float" val="0"/>
 						<measure name="models" type="int" val="0"/>
 						<measure name="status" type="string" val="UNSATISFIABLE"/>
-						<measure name="time" type="float" val="0.31"/>
 						<measure name="timeout" type="float" val="0"/>
 					</run>
 					<run number="2">
@@ -198,7 +197,6 @@
 						<measure name="memout" type="float" val="0"/>
 						<measure name="models" type="int" val="0"/>
 						<measure name="status" type="string" val="UNSATISFIABLE"/>
-						<measure name="time" type="float" val="0.31"/>
 						<measure name="timeout" type="float" val="0"/>
 					</run>
 				</instance>
@@ -213,7 +211,6 @@
 						<measure name="models" type="int" val="1"/>
 						<measure name="restarts" type="float" val="0.0"/>
 						<measure name="status" type="string" val="SATISFIABLE"/>
-						<measure name="time" type="float" val="0.14"/>
 						<measure name="timeout" type="float" val="0"/>
 					</run>
 					<run number="2">
@@ -224,7 +221,6 @@
 						<measure name="models" type="int" val="1"/>
 						<measure name="restarts" type="float" val="0.0"/>
 						<measure name="status" type="string" val="SATISFIABLE"/>
-						<measure name="time" type="float" val="0.14"/>
 						<measure name="timeout" type="float" val="0"/>
 					</run>
 				</instance>
@@ -237,7 +233,6 @@
 						<measure name="models" type="int" val="1"/>
 						<measure name="restarts" type="float" val="0.0"/>
 						<measure name="status" type="string" val="SATISFIABLE"/>
-						<measure name="time" type="float" val="0.19"/>
 						<measure name="timeout" type="float" val="0"/>
 					</run>
 					<run number="2">
@@ -248,7 +243,6 @@
 						<measure name="models" type="int" val="1"/>
 						<measure name="restarts" type="float" val="0.0"/>
 						<measure name="status" type="string" val="SATISFIABLE"/>
-						<measure name="time" type="float" val="0.19"/>
 						<measure name="timeout" type="float" val="0"/>
 					</run>
 				</instance>

--- a/tests/result/test_ods_gen.py
+++ b/tests/result/test_ods_gen.py
@@ -212,7 +212,7 @@ class TestInstSheet(TestCase):
         self.ref_val[13] = ["min", "time", 0.1]
         self.ref_val[14] = [np.nan, "timeout", 0]
         self.ref_val[15] = [np.nan, "models", 0]
-        self.ref_val[16] = ["median", "time", 0.31]
+        self.ref_val[16] = ["median", "time", 3.55]
         self.ref_val[17] = [np.nan, "timeout", 0]
         self.ref_val[18] = [np.nan, "models", 0]
         self.ref_val[19] = ["max", "time", 7]
@@ -373,6 +373,9 @@ class TestInstSheet(TestCase):
                     self.assertTrue(pd.isna(test_val))
                 else:
                     self.assertEqual(test_val, ref_val)
+        # dont gen summary for empty columns while other settings have results
+        for row in range(2, len(sheet.content.index)):
+            self.assertTrue(pd.isna(sheet.content.at[row, 9]))
 
     def test_add_styles(self) -> None:
         """
@@ -479,7 +482,7 @@ class TestClassSheet(TestInstSheet):
         self.ref_val[13] = ["min", "time", 0.20500000000000002]
         self.ref_val[14] = [np.nan, "timeout", 0]
         self.ref_val[15] = [np.nan, "models", 0]
-        self.ref_val[16] = ["median", "time", 0.31]
+        self.ref_val[16] = ["median", "time", 4.3525]
         self.ref_val[17] = [np.nan, "timeout", 0]
         self.ref_val[18] = [np.nan, "models", 0]
         self.ref_val[19] = ["max", "time", 8.5]


### PR DESCRIPTION
If some measures where completely missing in some settings, the ods gen would either fail or be incomplete depending on the order of settings.